### PR TITLE
Update 04.md

### DIFF
--- a/04.md
+++ b/04.md
@@ -107,6 +107,12 @@ There is only one Synth output, and therefore all the issued Synth must be sent 
 covenant via this output. The `Mint` covenant code can therefore use the amount of this unblinded
 output as the amount issued, even if the issuance data in the input 0 is confidential
 
+There could be an argument that 'exactly two inputs' restriction is not needed, as one can use
+`OP_PUSHCURRENTINPUTINDEX` to get the scriptpubkey of the RT output being spent and to compare
+it to output 0 scriptpubkey. But allowing more inputs would allow spending more than one RT utxo
+in the same Mint transaction, with value of that utxo being consolidated in output 0.
+This is not desireable, as it will allow reducing the number of RT utxo available for use in minting
+
 ## Claim covenant
 
 The `Release` branch of the `Claim` covenant code must ensure the following:


### PR DESCRIPTION
Add note on why we have to use 'only two inputs' restriction