### PR TITLE
Update 04.md

### DIFF
--- a/04.md
+++ b/04.md
@@ -73,7 +73,6 @@ incentive for Treasury or the public to perform the monitoring and burning
 To unlock reissuance token (RT), Mint covenant code must ensure the following:
 
 - Transaction contains exactly two inputs
-  * Input 0 is not restricted in any way, but will contain RT by construction
   * Input 1 is unblined, and contains L-BTC
 
 - Transaction contains four or five outputs


### PR DESCRIPTION
Remove a line about input 0 from the description of input restrictions of Claim covenant - it is enough that we talk below that this input is not restricted, talking about it in the list of the restrictions only adds confusion